### PR TITLE
add functions for cost

### DIFF
--- a/src/trip-functions.js
+++ b/src/trip-functions.js
@@ -15,6 +15,43 @@ export const filterPendingTrips = (trips) => trips.filter(trip => trip.status ==
 
 export const getAllTravelerTrips = (traveler, tripData) => sortTripsByDateDesc(filterTripsByUser(tripData, traveler.id));
 
+const filterTripsByYearAndStatus = (trips, year, status) =>
+  trips.filter(trip => dayjs(trip.date).year() === year && trip.status === status);
+
+export const getTravelCostForYearToDate = (trips, destinationData, cost, multiplier) => {
+  const currentYear = dayjs().year();
+  const filteredTrips = filterTripsByYearAndStatus(trips, currentYear, 'approved');
+  
+  const travelCost = filteredTrips.reduce((total, trip) => {
+    const destination = destinationData.find(dest => dest.id === trip.destinationID);
+    if (destination) {
+      return total + trip[multiplier] * destination[cost];
+    }
+    return total;
+  }, 0);
+  
+  return travelCost.toFixed(2);
+};
+
+export const getTotalSpentForYearToDate = (trips, destinationData) => {
+  const currentYear = dayjs().year();
+  const filteredTrips = filterTripsByYearAndStatus(trips, currentYear, 'approved');
+  
+  const spentThisYear = filteredTrips.reduce((total, trip) => {
+    const destination = destinationData.find(dest => dest.id === trip.destinationID);
+    if (destination) {
+      const tripCost = (trip.duration * destination.estimatedLodgingCostPerDay) + (trip.travelers * destination.estimatedFlightCostPerPerson);
+      console.log('Trip Cost:', tripCost);
+      return total + tripCost;
+    }
+    return total;
+  }, 0);
+  
+  console.log('Total Spent This Year:', spentThisYear);
+  
+  return (spentThisYear * 1.1).toFixed(2);
+};
+
 export const createTripRepository = (traveler, tripData) => {
   const allTravelerTrips = getAllTravelerTrips(traveler, tripData);
   const pastTrips = filterPastTrips(allTravelerTrips);

--- a/test/trip-test.js
+++ b/test/trip-test.js
@@ -7,20 +7,20 @@ describe('createTrip', () => {
 
   beforeEach(() => {
     const mockTripCopy = mockTrip
-    console.log('Mock Trip Data (beforeEach):', JSON.stringify(mockTripCopy, null, 2));
+    // console.log('Mock Trip Data (beforeEach):', JSON.stringify(mockTripCopy, null, 2));
 
     validTripData = mockTripCopy[0];
     anotherValidTripData = mockTripCopy[1];
     invalidTripData = {};
 
-    console.log('Valid Trip Data (beforeEach):', validTripData);
-    console.log('Another Valid Trip Data (beforeEach):', anotherValidTripData);
-    console.log('Invalid Trip Data (beforeEach):', invalidTripData);
+    // console.log('Valid Trip Data (beforeEach):', validTripData);
+    // console.log('Another Valid Trip Data (beforeEach):', anotherValidTripData);
+    // console.log('Invalid Trip Data (beforeEach):', invalidTripData);
   });
 
   it('should create a trip object with correct properties (happy path)', () => {
     const trip = createTrip(validTripData);
-    console.log('Created Trip (happy path 1):', trip);
+    // console.log('Created Trip (happy path 1):', trip);
 
     expect(trip).to.be.an('object');
     expect(trip).to.have.property('id', 1);
@@ -35,7 +35,7 @@ describe('createTrip', () => {
 
   it('should create another trip object with correct properties (happy path)', () => {
     const trip = createTrip(anotherValidTripData);
-    console.log('Created Trip (happy path 2):', trip); 
+    // console.log('Created Trip (happy path 2):', trip); 
 
     expect(trip).to.be.an('object');
     expect(trip).to.have.property('id', 2);
@@ -50,7 +50,7 @@ describe('createTrip', () => {
 
   it('should handle invalid data gracefully (sad path)', () => {
     const trip = createTrip(invalidTripData);
-    console.log('Created Trip (sad path 1):', trip);
+    // console.log('Created Trip (sad path 1):', trip);
 
     expect(trip).to.be.an('object');
     expect(trip).to.not.have.property('id');
@@ -66,7 +66,7 @@ describe('createTrip', () => {
   it('should handle another set of invalid data gracefully (sad path)', () => {
     const invalidTripData2 = { id: 'invalid', userID: 'wrong', destinationID: null, travelers: 'invalid', date: 12345, duration: 'wrong', status: false, suggestedActivities: 'not an array' };
     const trip = createTrip(invalidTripData2);
-    console.log('Created Trip (sad path 2):', trip);
+    // console.log('Created Trip (sad path 2):', trip);
 
     expect(trip).to.be.an('object');
     expect(trip).to.not.have.property('id');


### PR DESCRIPTION
### Description
This pull request introduces two new functions, getTravelCostForYearToDate and getTotalSpentForYearToDate, along with their respective tests. These functions are designed to calculate travel costs and total expenditure for the current year to date.

### New Functions
**getTravelCostForYearToDate**

_Purpose_: Calculates the total travel cost for the current year to date based on specific cost attributes for each trip.
_Parameters_:
trips: Array of trip objects.
destinationData: Array of destination objects.
cost: String indicating which cost to consider from the destination data (e.g., estimatedFlightCostPerPerson).
multiplier: String indicating which multiplier to consider from the trip data (e.g., travelers).

**getTotalSpentForYearToDate**

_Purpose_: Calculates the total amount spent for travel for the current year to date, considering both lodging and flight costs for all approved trips within the current year, and adds a 10% fee.
_Parameters_:
trips: Array of trip objects.
destinationData: Array of destination objects.

### Tests
The test suite for these functions ensures their correctness and robustness. The tests cover both happy paths (valid scenarios) and sad paths (edge cases and invalid scenarios).

Test Cases for getTravelCostForYearToDate

Should calculate the travel cost for the year to date (happy path).
Should return 0.00 if there are no matching trips (sad path).
Test Cases for getTotalSpentForYearToDate

Should calculate the total spent for the year to date (happy path).
Should return 0.00 if there are no matching trips (sad path).
